### PR TITLE
When attacking weakest neighbour, deprioritize own kind

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -139,7 +139,14 @@ impl Battle
         *candidates.iter().max_by_key(|candidate|
         {
             let neighbour = &self.pokemons[candidate.y][candidate.x];
-            get_effectiveness_with_type(pokemon.kind, neighbour.kind)
+            if pokemon.kind != neighbour.kind
+            {
+                get_effectiveness_with_type(pokemon.kind, neighbour.kind)
+            }
+            else
+            {
+                0
+            }
         }).unwrap()
     }
 


### PR DESCRIPTION
For some pokemon types, the weakest neighbour can be their own type. The in-fighting prevents this type from gaining territory. With this change, own kind will only be attacked if no alternatives are present.