### PR TITLE
Cleaned up imports

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -1,7 +1,8 @@
 use rand::distributions::Uniform;
 use rand::Rng;
 
-use crate::{Pokemon, POKEMON_COUNT, get_effectiveness_with_type};
+use crate::pokemon::{Pokemon, get_effectiveness_with_type};
+use crate::types::POKEMON_COUNT;
 
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Location

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use nannou::prelude::*;
+use nannou::prelude::{App, Frame, Update, WindowEvent};
 use nannou::image::GenericImageView;
 
 mod types;
@@ -63,7 +63,7 @@ fn model(app: &App) -> Model
     app.new_window()
        .size(img_width as u32, img_height as u32)
        .surface_conf_builder(surface_conf_builder)
-       .clear_color(PURPLE)
+       .clear_color(nannou::color::PURPLE)
        .view(view)
        .event(event)
        .build()
@@ -93,7 +93,7 @@ fn update(_app: &App, model: &mut Model, _update: Update)
 
 fn view(app: &App, model: &Model, frame: Frame)
 {
-    let texture = wgpu::Texture::from_image(app, &model.image);
+    let texture = nannou::wgpu::Texture::from_image(app, &model.image);
     let (image_width, image_height) = model.image.dimensions();
     let width_ratio = model.window_width as f32 / image_width as f32;
     let height_ratio = model.window_height as f32 / image_height as f32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,9 @@ use nannou::prelude::*;
 use nannou::image::GenericImageView;
 
 mod types;
-use crate::types::*;
-
 mod pokemon;
-use crate::pokemon::*;
-
 mod battle;
-use crate::battle::*;
+use battle::{Battle, SelectionAlgorithm};
 
 /// Pokemon battle simulation
 #[derive(Parser, Debug)]

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -71,7 +71,6 @@ impl Pokemon
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::distributions::Uniform;
 
     #[test]
     fn test_get_effectiveness()

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -1,7 +1,7 @@
 use rand::prelude::ThreadRng;
 use rand::distributions::Uniform;
 
-use crate::{PokemonType, POKEMON_COUNT};
+use crate::types::{PokemonType, POKEMON_COUNT};
 
 pub const POKEMON: [[i32; POKEMON_COUNT]; POKEMON_COUNT] = [
 	[ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  50,   0, 100, 100,  50, 100 ], // Normal
@@ -70,8 +70,7 @@ impl Pokemon
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{PokemonType, POKEMON_COUNT};
-    use crate::{Pokemon, get_effectiveness_with_type};
+    use super::*;
     use rand::distributions::Uniform;
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -76,7 +76,7 @@ impl From<PokemonType> for Rgb<u8>
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{PokemonType};
+    use super::*;
 
     #[test]
     fn convert_type_from_usize()


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/#wildcard_imports for recommendations on imports. This rule isn’t enforced by default but running `cargo clippy -- -W clippy::wildcard_imports` will make the warnings show up. In general, importing stuff in `main.rs` that isn’t used there but is transitively imported elsewhere is very confusing. Also, `use super::*` in tests usually takes care of all import needs.