### PR TITLE
Optimize dev builds to make them usable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ clap = { version = "3.1.17", features = ["derive"] }
 rand = "0.8.5"
 nannou = "0.18.1"
 strum = { version = "0.24", features = ["derive"] }
+
+[profile.dev]
+opt-level = 3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rust project that simulates a grid of Pokémon fighting with each other.
 
 Each Pokémon type is a pixel on the grid and is represented by a color.
 
-Every frame an attack is done by a Pokémon that will pick a random neighbour, 
+Every frame an attack is done by a Pokémon that will pick a random neighbour,
 if that neighbour faints they will turn into a pokemon of the same type as the attacker.
 
 Some Pokémon types do more or less damage to other types, which is what this is trying to simulate.
@@ -14,7 +14,7 @@ Some Pokémon types do more or less damage to other types, which is what this is
 ## Build
 
 ```
-cargo r --release
+cargo run
 ```
 
 Depends on `nannou` for the Window


### PR DESCRIPTION
Presumably, you are suggesting to run release builds because dev build performance is just too bad. With this change dev build is optimized and usable. It still has all the debug foo in it and should be better suited for development.