### PR TITLE
Generalize Battle to work on abstract fighters, not pokemons

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use nannou::image::GenericImageView;
 mod types;
 mod pokemon;
 mod battle;
+
 use battle::{Battle, SelectionAlgorithm};
+use pokemon::{Pokemon};
 
 /// Pokemon battle simulation
 #[derive(Parser, Debug)]
@@ -50,7 +52,7 @@ fn validate_size(arg: &str) -> Result<(), String>
 
 struct Model
 {
-    battle: Battle,
+    battle: Battle<Pokemon>,
     image: nannou::image::DynamicImage,
     window_width: u32,
     window_height: u32,
@@ -77,7 +79,7 @@ fn model(app: &App) -> Model
        .unwrap();
 
     Model {
-        battle: Battle::new(img_width, img_height, selection_algorithm),
+        battle: Battle::new(Pokemon::generate_randomly(), img_width, img_height, selection_algorithm),
         image: nannou::image::DynamicImage::ImageRgb8(nannou::image::RgbImage::new(img_width as u32, img_height as u32)),
         window_width: img_width as u32,
         window_height: img_height as u32,
@@ -95,8 +97,8 @@ fn update(_app: &App, model: &mut Model, _update: Update)
     {
         for (x, y, pixel) in pixels.enumerate_pixels_mut()
         {
-            let pokemon = model.battle.pokemon(x, y);
-            *pixel = pokemon.kind.into();
+            let pokemon = model.battle.fighter(x, y);
+            *pixel = pokemon.color();
         }
     }
 

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -1,7 +1,7 @@
-use rand::prelude::ThreadRng;
 use rand::distributions::Uniform;
 
 use crate::types::{PokemonType, POKEMON_COUNT};
+use crate::battle::Fighter;
 
 pub const POKEMON: [[i32; POKEMON_COUNT]; POKEMON_COUNT] = [
 	[ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  50,   0, 100, 100,  50, 100 ], // Normal
@@ -24,47 +24,80 @@ pub const POKEMON: [[i32; POKEMON_COUNT]; POKEMON_COUNT] = [
 	[ 100,  50, 100, 100, 100, 100, 200,  50, 100, 100, 100, 100, 100, 100, 200, 200,  50, 100 ]  // Fairy
 ];
 
-pub fn get_effectiveness(attacker: usize, defender: usize) -> i32
+fn get_effectiveness(attacker: usize, defender: usize) -> i32
 {
     POKEMON[attacker][defender]
-}
-
-pub fn get_effectiveness_with_type(attacker: PokemonType, defender: PokemonType) -> i32
-{
-    get_effectiveness(attacker.into(), defender.into())
 }
 
 #[derive(Clone)]
 pub struct Pokemon
 {
-    pub health: i32,
-    pub damage: i32,
-    pub kind: PokemonType,
+    health: i32,
+    damage: i32,
+    kind: PokemonType,
 }
 
 impl Pokemon
 {
-    pub fn random(rng: &mut ThreadRng, die: &Uniform<usize>) -> Self
+    pub fn new(kind: PokemonType) -> Self
     {
         Pokemon {
             health: 80,
             damage: 40,
-            kind: PokemonType::random(rng, die)
+            kind
         }
     }
 
-    pub fn reset(&mut self, kind: PokemonType)
+    pub fn generate_randomly() -> impl Iterator<Item = Self>
+    {
+        let mut rng = rand::thread_rng();
+        let die = Uniform::from(0 .. POKEMON_COUNT);
+        (0..).map(move |_| Self::new(PokemonType::random(&mut rng, &die)))
+    }
+
+    pub fn color(&self) -> nannou::image::Rgb<u8>
+    {
+        self.kind.into()
+    }
+
+    fn reset(&mut self, kind: PokemonType)
     {
         self.health = 80;
         self.damage = 40;
         self.kind = kind;
     }
 
-    pub fn take_damage(&mut self, damage: i32) -> bool
+    fn take_damage(&mut self, damage: i32) -> bool
     {
         self.health -= damage;
 
         self.health <= 0
+    }
+}
+
+impl Fighter for Pokemon
+{
+    fn should_fight(&self, defender: &Self) -> bool
+    {
+        self.kind != defender.kind
+    }
+
+    fn get_effectiveness(&self, defender: &Self) -> i32
+    {
+        get_effectiveness(self.kind.into(), defender.kind.into())
+    }
+
+    fn fight(&self, defender: &mut Self) -> bool
+    {
+        let effectiveness = self.get_effectiveness(defender);
+        let damage = self.damage * effectiveness / 100;
+
+        let is_dead = defender.take_damage(damage);
+        if is_dead
+        {
+            defender.reset(self.kind);
+        }
+        is_dead
     }
 }
 
@@ -75,18 +108,15 @@ mod tests {
     #[test]
     fn test_get_effectiveness()
     {
-        assert_eq!(get_effectiveness_with_type(PokemonType::Normal, PokemonType::Normal), 100);
-        assert_eq!(get_effectiveness_with_type(PokemonType::Fire, PokemonType::Steel), 200);
-        assert_eq!(get_effectiveness_with_type(PokemonType::Water, PokemonType::Grass),  50);
+        assert_eq!(Pokemon::new(PokemonType::Normal).get_effectiveness(&Pokemon::new(PokemonType::Normal)), 100);
+        assert_eq!(Pokemon::new(PokemonType::Fire).get_effectiveness(&Pokemon::new(PokemonType::Steel)), 200);
+        assert_eq!(Pokemon::new(PokemonType::Water).get_effectiveness(&Pokemon::new(PokemonType::Grass)), 50);
     }
 
     #[test]
     fn test_damage()
     {
-        let mut rng = rand::thread_rng();
-        let die = Uniform::from(0 .. POKEMON_COUNT);
-
-        let mut p1 = Pokemon::random(&mut rng, &die);
+        let mut p1 = Pokemon::new(PokemonType::Normal);
         let health = p1.health;
         let dead = p1.take_damage(40);
 
@@ -103,10 +133,7 @@ mod tests {
     #[test]
     fn test_reset()
     {
-        let mut rng = rand::thread_rng();
-        let die = Uniform::from(0 .. POKEMON_COUNT);
-
-        let mut p1 = Pokemon::random(&mut rng, &die);
+        let mut p1 = Pokemon::new(PokemonType::Normal);
         p1.reset(PokemonType::Fire);
         assert_eq!(p1.kind, PokemonType::Fire);
 


### PR DESCRIPTION
This fixes #14, all mostly straightforward. The only complication is that `Battle::fight` needs two fighter references, one mutable, and the previous work-around no longer works with the types being opaque. The solution to split the vector into multiple independent slices might help with multithreading as well.