### PR TITLE
Made handling of in-fighting consistent, only allowed with -o command line flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,10 @@ struct Args
     /// Measure frame rate and print it to stdout
     #[clap(short='f', long)]
     framerate: bool,
+
+    /// Let fighters fight their own kind
+    #[clap(short='o', long)]
+    fightown: bool,
 }
 
 fn main()
@@ -83,7 +87,7 @@ fn model(app: &App) -> Model
        .unwrap();
 
     Model {
-        battle: Battle::new(RPS::generate_randomly(), img_width, img_height, selection_algorithm),
+        battle: Battle::new(RPS::generate_randomly(), img_width, img_height, selection_algorithm, !args.fightown),
         image: nannou::image::DynamicImage::ImageRgb8(nannou::image::RgbImage::new(img_width as u32, img_height as u32)),
         window_width: img_width as u32,
         window_height: img_height as u32,


### PR DESCRIPTION
With this change, the `--fightown` command line flag determines whether own kind is attacked or not. If it’s the latter, no attack happens at all (previously it would still attack if no other pokemon were around).

The challenge here was implementing this without hurting performance too much. That’s why I have `weakest_neighbour` and `weakest_neighbour_filtered` as separate functions – any kind of decision making inside the function would degrade performance. And I choose the callback up front now so this choice doesn’t have to happen within the loop (I strongly suspect though that Rust already optimized that choice out of the loop before).