### PR TITLE
Moved all pokemon-related types into pokemon.rs

### DIFF
--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -1,10 +1,79 @@
 use rand::distributions::Uniform;
 use rand::Rng;
+use strum::{FromRepr,EnumCount};
 
-use crate::types::{PokemonType, POKEMON_COUNT, RandomlyGeneratable, Colored};
+use crate::types::{RandomlyGeneratable, Colored};
 use crate::battle::Fighter;
 
-const EFFICIENCY: [[i32; POKEMON_COUNT]; POKEMON_COUNT] = [
+#[derive(Clone, Copy, Debug, Eq, PartialEq, EnumCount, FromRepr)]
+#[repr(usize)]
+pub enum PokemonType
+{
+	Normal,
+	Fire,
+	Water,
+	Electric,
+	Grass,
+	Ice,
+	Fighting,
+	Poison,
+	Ground,
+	Flying,
+	Psychic,
+	Bug,
+	Rock,
+	Ghost,
+	Dragon,
+	Dark,
+	Steel,
+	Fairy
+}
+
+impl From<usize> for PokemonType
+{
+    fn from(repr: usize) -> Self
+    {
+        Self::from_repr(repr).unwrap()
+    }
+}
+
+impl From<PokemonType> for usize
+{
+    fn from(kind: PokemonType) -> Self
+    {
+        kind as Self
+    }
+}
+
+impl From<PokemonType> for nannou::image::Rgb<u8>
+{
+	fn from(kind: PokemonType) -> Self
+	{
+		match kind
+		{
+			PokemonType::Normal => [168,168,120],
+			PokemonType::Fire => [240,128,48],
+			PokemonType::Water => [104,144,240],
+			PokemonType::Electric => [248,208,48],
+			PokemonType::Grass => [120,200,80],
+			PokemonType::Ice => [152,216,216],
+			PokemonType::Fighting => [192,48,40],
+			PokemonType::Poison => [160,64,160],
+			PokemonType::Ground => [224,192,104],
+			PokemonType::Flying => [168,144,240],
+			PokemonType::Psychic => [248,88,136],
+			PokemonType::Bug => [168,184,32],
+			PokemonType::Rock => [184,160,56],
+			PokemonType::Ghost => [112,88,152],
+			PokemonType::Dragon => [112,56,248],
+			PokemonType::Dark => [112,88,72],
+			PokemonType::Steel => [184,184,208],
+			PokemonType::Fairy => [240,182,188],
+		}.into()
+    }
+}
+
+const EFFICIENCY: [[i32; PokemonType::COUNT]; PokemonType::COUNT] = [
 	[ 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100,  50,   0, 100, 100,  50, 100 ], // Normal
 	[ 100,  50,  50, 100, 200, 200, 100, 100, 100, 100, 100, 200,  50, 100,  50, 100, 200, 100 ], // Fire
 	[ 100, 200,  50, 100,  50, 100, 100, 100, 200, 100, 100, 100, 200, 100,  50, 100, 100, 100 ], // Water
@@ -95,7 +164,7 @@ impl RandomlyGeneratable for Pokemon
     fn generate_randomly() -> Box<dyn Iterator<Item=Self>>
     {
         let rng = rand::thread_rng();
-        Box::new(rng.sample_iter(Uniform::from(0..POKEMON_COUNT)).map(|t| Self::new(t.into())))
+        Box::new(rng.sample_iter(Uniform::from(0..PokemonType::COUNT)).map(|t| Self::new(t.into())))
     }
 }
 
@@ -110,6 +179,13 @@ impl Colored for Pokemon
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn convert_type_from_usize()
+    {
+        assert_eq!(PokemonType::from_repr(0).unwrap(), PokemonType::Normal);
+        assert_eq!(PokemonType::from_repr(17).unwrap(), PokemonType::Fairy);
+    }
 
     #[test]
     fn test_get_effectiveness()

--- a/src/rps.rs
+++ b/src/rps.rs
@@ -16,8 +16,6 @@ pub enum RPSType
     Scissor,
 }
 
-pub const RPS_COUNT: usize = RPSType::COUNT;
-
 impl RPSType
 {
     pub fn random(rng: &mut ThreadRng, die: &Uniform<usize>) -> Self
@@ -132,7 +130,7 @@ impl RandomlyGeneratable for RPS
     fn generate_randomly() -> Box<dyn Iterator<Item=Self>>
     {
         let rng = rand::thread_rng();
-        Box::new(rng.sample_iter(Uniform::from(0..RPS_COUNT)).map(|t| Self::new(t.into())))
+        Box::new(rng.sample_iter(Uniform::from(0..RPSType::COUNT)).map(|t| Self::new(t.into())))
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,5 @@
 use rand::distributions::{Distribution, Uniform};
 use rand::prelude::ThreadRng;
-use strum::{FromRepr,EnumCount};
 
 #[derive(Debug)]
 pub enum FighterType
@@ -44,86 +43,4 @@ pub trait RandomlyGeneratable
 pub trait Colored
 {
     fn color(&self) -> nannou::image::Rgb<u8>;
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, EnumCount, FromRepr)]
-#[repr(usize)]
-pub enum PokemonType
-{
-	Normal,
-	Fire,
-	Water,
-	Electric,
-	Grass,
-	Ice,
-	Fighting,
-	Poison,
-	Ground,
-	Flying,
-	Psychic,
-	Bug,
-	Rock,
-	Ghost,
-	Dragon,
-	Dark,
-	Steel,
-	Fairy
-}
-
-pub const POKEMON_COUNT: usize = PokemonType::COUNT;
-
-impl From<usize> for PokemonType
-{
-    fn from(repr: usize) -> Self
-    {
-        Self::from_repr(repr).unwrap()
-    }
-}
-
-impl From<PokemonType> for usize
-{
-    fn from(kind: PokemonType) -> Self
-    {
-        kind as Self
-    }
-}
-
-impl From<PokemonType> for nannou::image::Rgb<u8>
-{
-	fn from(kind: PokemonType) -> Self
-	{
-		match kind
-		{
-			PokemonType::Normal => [168,168,120],
-			PokemonType::Fire => [240,128,48],
-			PokemonType::Water => [104,144,240],
-			PokemonType::Electric => [248,208,48],
-			PokemonType::Grass => [120,200,80],
-			PokemonType::Ice => [152,216,216],
-			PokemonType::Fighting => [192,48,40],
-			PokemonType::Poison => [160,64,160],
-			PokemonType::Ground => [224,192,104],
-			PokemonType::Flying => [168,144,240],
-			PokemonType::Psychic => [248,88,136],
-			PokemonType::Bug => [168,184,32],
-			PokemonType::Rock => [184,160,56],
-			PokemonType::Ghost => [112,88,152],
-			PokemonType::Dragon => [112,56,248],
-			PokemonType::Dark => [112,88,72],
-			PokemonType::Steel => [184,184,208],
-			PokemonType::Fairy => [240,182,188],
-		}.into()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn convert_type_from_usize()
-    {
-        assert_eq!(PokemonType::from_repr(0).unwrap(), PokemonType::Normal);
-        assert_eq!(PokemonType::from_repr(17).unwrap(), PokemonType::Fairy);
-    }
 }


### PR DESCRIPTION
Got rid of pointless `POKEMON_COUNT` and `RPS_COUNT` constants while at it. The point was not requiring any consumers to import `strum::EnumCount`, but that size is used only internally now.