### PR TITLE
Reworked fighter generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ name = "poke-fighting-rust"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "lazy_static",
  "nannou",
  "rand 0.8.5",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.1.17", features = ["derive"] }
 rand = "0.8.5"
+lazy_static = "1.4"
 nannou = "0.18.1"
 strum = { version = "0.24", features = ["derive"] }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ pub use battle::{Battle, Fighter, SelectionAlgorithm};
 pub use pokemon::Pokemon;
 pub use rps::RPS;
 pub use street_fighter::StreetFighter;
-pub use types::{Colored, RandomlyGeneratable};
+pub use types::{Colored, GenerateRandomly};

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use clap::{ArgEnum, Parser};
 use nannou::image::GenericImageView;
 use nannou::prelude::{App, Frame, Update, WindowEvent};
 use poke_fighting_rust::{
-    Battle, Colored, Fighter, Pokemon, RandomlyGeneratable, SelectionAlgorithm, StreetFighter, RPS,
+    Battle, Colored, Fighter, GenerateRandomly, Pokemon, SelectionAlgorithm, StreetFighter, RPS,
 };
 
 /// Battle simulation
@@ -52,7 +52,7 @@ fn main() {
 
 fn run_app<T>()
 where
-    T: 'static + Colored + Fighter + RandomlyGeneratable,
+    T: 'static + Colored + Fighter + GenerateRandomly,
 {
     nannou::app(model::<T>).update(update).exit(exit).run()
 }
@@ -78,7 +78,7 @@ struct Model<T> {
     counter: usize,
 }
 
-fn model<T: 'static + Fighter + RandomlyGeneratable>(app: &App) -> Model<T> {
+fn model<T: 'static + Fighter + GenerateRandomly>(app: &App) -> Model<T> {
     let args = Args::parse();
     let img_width = args.width;
     let img_height = args.height;
@@ -100,13 +100,7 @@ fn model<T: 'static + Fighter + RandomlyGeneratable>(app: &App) -> Model<T> {
         .unwrap();
 
     Model {
-        battle: Battle::new(
-            T::generate_randomly(),
-            img_width,
-            img_height,
-            selection_algorithm,
-            !args.fightown,
-        ),
+        battle: Battle::new(img_width, img_height, selection_algorithm, !args.fightown),
         image: nannou::image::DynamicImage::ImageRgb8(nannou::image::RgbImage::new(
             img_width as u32,
             img_height as u32,

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -1,6 +1,7 @@
 use crate::battle::Fighter;
-use crate::types::{Colored, RandomlyGeneratable};
-use rand::distributions::Uniform;
+use crate::types::{Colored, GenerateRandomly};
+use lazy_static::lazy_static;
+use rand::distributions::{Distribution, Uniform};
 use rand::Rng;
 use strum::{EnumCount, FromRepr};
 
@@ -141,13 +142,17 @@ impl Fighter for Pokemon {
     }
 }
 
-impl RandomlyGeneratable for Pokemon {
-    fn generate_randomly() -> Box<dyn Iterator<Item = Self>> {
-        let rng = rand::thread_rng();
-        Box::new(
-            rng.sample_iter(Uniform::from(0..PokemonType::COUNT))
-                .map(|t| Self::new(t.into())),
-        )
+lazy_static! {
+    static ref DISTRIBUTION: Uniform<usize> = Uniform::new(0, PokemonType::COUNT);
+}
+
+impl GenerateRandomly for Pokemon {
+    fn generate_randomly<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        let t = DISTRIBUTION.sample(rng);
+        Self::new(t.into())
     }
 }
 

--- a/src/rps.rs
+++ b/src/rps.rs
@@ -1,7 +1,7 @@
 use crate::battle::Fighter;
-use crate::types::{Colored, RandomlyGeneratable};
+use crate::types::{Colored, GenerateRandomly};
+use lazy_static::lazy_static;
 use rand::distributions::{Distribution, Uniform};
-use rand::prelude::ThreadRng;
 use rand::Rng;
 use strum::{EnumCount, FromRepr};
 
@@ -11,13 +11,6 @@ pub enum RPSType {
     Rock,
     Paper,
     Scissor,
-}
-
-impl RPSType {
-    pub fn random(rng: &mut ThreadRng, die: &Uniform<usize>) -> Self {
-        let value = die.sample(rng);
-        RPSType::from_repr(value).unwrap()
-    }
 }
 
 impl From<usize> for RPSType {
@@ -104,13 +97,17 @@ impl Fighter for RPS {
     }
 }
 
-impl RandomlyGeneratable for RPS {
-    fn generate_randomly() -> Box<dyn Iterator<Item = Self>> {
-        let rng = rand::thread_rng();
-        Box::new(
-            rng.sample_iter(Uniform::from(0..RPSType::COUNT))
-                .map(|t| Self::new(t.into())),
-        )
+lazy_static! {
+    static ref DISTRIBUTION: Uniform<usize> = Uniform::new(0, RPSType::COUNT);
+}
+
+impl GenerateRandomly for RPS {
+    fn generate_randomly<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        let t = DISTRIBUTION.sample(rng);
+        Self::new(t.into())
     }
 }
 

--- a/src/street_fighter.rs
+++ b/src/street_fighter.rs
@@ -4,9 +4,9 @@
 // And OCR does not handle them well.
 
 use crate::battle::Fighter;
-use crate::types::{Colored, RandomlyGeneratable};
+use crate::types::{Colored, GenerateRandomly};
+use lazy_static::lazy_static;
 use rand::distributions::{Distribution, Uniform};
-use rand::prelude::ThreadRng;
 use rand::Rng;
 use strum::{EnumCount, FromRepr};
 
@@ -52,13 +52,6 @@ pub enum StreetFighterType {
     Hakan,
     THawk,
     Dan,
-}
-
-impl StreetFighterType {
-    pub fn random(rng: &mut ThreadRng, die: &Uniform<usize>) -> Self {
-        let value = die.sample(rng);
-        StreetFighterType::from_repr(value).unwrap()
-    }
 }
 
 impl From<usize> for StreetFighterType {
@@ -216,13 +209,17 @@ impl Fighter for StreetFighter {
     }
 }
 
-impl RandomlyGeneratable for StreetFighter {
-    fn generate_randomly() -> Box<dyn Iterator<Item = Self>> {
-        let rng = rand::thread_rng();
-        Box::new(
-            rng.sample_iter(Uniform::from(0..StreetFighterType::COUNT))
-                .map(|t| Self::new(t.into())),
-        )
+lazy_static! {
+    static ref DISTRIBUTION: Uniform<usize> = Uniform::new(0, StreetFighterType::COUNT);
+}
+
+impl GenerateRandomly for StreetFighter {
+    fn generate_randomly<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        let t = DISTRIBUTION.sample(rng);
+        Self::new(t.into())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,9 @@
-pub trait RandomlyGeneratable {
-    fn generate_randomly() -> Box<dyn Iterator<Item = Self>>;
+use rand::Rng;
+
+pub trait GenerateRandomly {
+    fn generate_randomly<R>(rng: &mut R) -> Self
+    where
+        R: Rng;
 }
 
 pub trait Colored {


### PR DESCRIPTION
Made use of std::iter::repeat_with
to construct the table of fighters.
Also migrated to the GenerateRandomly
trait, that generates one fighter at
a time (to be used with repeat_with)