### PR TITLE
Optimize access to the efficienty table

### DIFF
--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -88,8 +88,8 @@ const EFFICIENCY: [[i32; PokemonType::COUNT]; PokemonType::COUNT] = [
 	[ 100,  50, 100, 100, 100, 100, 200,  50, 100, 100, 100, 100, 100, 100, 200, 200,  50, 100 ]  // Fairy
 ];
 
-fn get_effectiveness(attacker: usize, defender: usize) -> i32 {
-    EFFICIENCY[attacker][defender]
+fn get_effectiveness(attacker: PokemonType, defender: PokemonType) -> i32 {
+    EFFICIENCY[attacker as usize][defender as usize]
 }
 
 #[derive(Clone)]
@@ -127,7 +127,7 @@ impl Fighter for Pokemon {
     }
 
     fn get_effectiveness(&self, defender: &Self) -> i32 {
-        get_effectiveness(self.kind.into(), defender.kind.into())
+        get_effectiveness(self.kind, defender.kind)
     }
 
     fn fight(&self, defender: &mut Self) -> bool {

--- a/src/rps.rs
+++ b/src/rps.rs
@@ -43,8 +43,8 @@ const EFFICIENCY: [[i32; RPSType::COUNT]; RPSType::COUNT] = [
     [   0, 100,   0 ], // Scissor
 ];
 
-fn get_effectiveness(attacker: usize, defender: usize) -> i32 {
-    EFFICIENCY[attacker][defender]
+fn get_effectiveness(attacker: RPSType, defender: RPSType) -> i32 {
+    EFFICIENCY[attacker as usize][defender as usize]
 }
 
 #[derive(Clone)]
@@ -82,7 +82,7 @@ impl Fighter for RPS {
     }
 
     fn get_effectiveness(&self, defender: &Self) -> i32 {
-        get_effectiveness(self.kind.into(), defender.kind.into())
+        get_effectiveness(self.kind, defender.kind)
     }
 
     fn fight(&self, defender: &mut Self) -> bool {

--- a/src/street_fighter.rs
+++ b/src/street_fighter.rs
@@ -156,8 +156,8 @@ const EFFICIENCY: [[i32; StreetFighterType::COUNT]; StreetFighterType::COUNT] = 
     [30, 40, 40, 40, 40, 30, 40, 40, 40, 40, 50, 40, 30, 40, 30, 40, 40, 30, 30, 40, 40, 40, 40, 40, 40, 40, 40, 40, 50, 40, 40, 40, 40, 40, 40, 40, 40, 40,  0],
 ];
 
-fn get_effectiveness(attacker: usize, defender: usize) -> i32 {
-    EFFICIENCY[attacker][defender]
+fn get_effectiveness(attacker: StreetFighterType, defender: StreetFighterType) -> i32 {
+    EFFICIENCY[attacker as usize][defender as usize]
 }
 
 #[derive(Clone)]
@@ -191,7 +191,7 @@ impl Fighter for StreetFighter {
     }
 
     fn get_effectiveness(&self, defender: &Self) -> i32 {
-        get_effectiveness(self.kind.into(), defender.kind.into())
+        get_effectiveness(self.kind, defender.kind)
     }
 
     fn fight(&self, defender: &mut Self) -> bool {


### PR DESCRIPTION
By using enum type and not usize, we can trick Rust
(or LLVM) to optimize bounds check away.