### PR TITLE
Fixed regression from #36: Wrong position calculation if width and height aren't identical

### DIFF
--- a/src/battle.rs
+++ b/src/battle.rs
@@ -74,7 +74,7 @@ where
         let mut current = start;
 
         loop {
-            let attacker_loc = (current % w, current / h);
+            let attacker_loc = (current % w, current / w);
             let defender_loc = (self.selection_callback)(self, attacker_loc, (w, h));
             if let Some(defender_loc) = defender_loc {
                 self.fight(attacker_loc, defender_loc);

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -63,8 +63,15 @@ mod tests {
 
     #[test]
     fn test_access() {
-        let grid = Grid2D::new_with((10, 2), || 1);
+        let mut grid = Grid2D::new_with((10, 2), || 1);
         assert_eq!(grid.get((9, 1)), Some(&1));
         assert_eq!(grid.get((1, 9)), None);
+
+        if let Some(pair) = grid.get_pair_mut((0, 0), (7, 1)) {
+            *pair.0 = 2;
+            *pair.1 = 3;
+        }
+        assert_eq!(grid.get((0, 0)), Some(&2));
+        assert_eq!(grid.get((7, 1)), Some(&3));
     }
 }


### PR DESCRIPTION
I noticed lines in the display if I specify an image size that’s not square. Turns out, this is a regression from #36: wrong calculation in `Battle::action()`.

While looking for the bug, I added a test making sure that `Grid2D::get_pair_mut()` operates on the same data as is returned by `Grid2D::get()` later. It’s probably a good idea to keep this one.